### PR TITLE
Add gh pages action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Deploy to GitHub Pages
 on: [push]
 
 permissions:
@@ -15,3 +15,16 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: game
+
+      # Comment with the address that the game is deployed to.
+      - name: Comment 🗣️
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Deployed to: https://<username>.github.io/<repo-name>`
+            })

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,16 +15,3 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: game
-
-      # Comment with the address that the game is deployed to.
-      - name: Comment 🗣️
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Deployed to: https://<username>.github.io/<repo-name>`
-            })

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,8 @@
 name: Deploy to GitHub Pages
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,17 @@
+name: Build and Deploy
+on: [push]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: game


### PR DESCRIPTION
This adds the workflow that can be used to push to GitHub pages. It requires that we go into settings, go to pages, and set the deployment branch to `gh-pages`, so we'll need to walk through that near the end. After that, when someone pushes changes to `main`, it will automatically deploy 👍 

![image](https://user-images.githubusercontent.com/14791619/235389466-18d09636-efc3-47fb-bd05-ad1adf5d6e9f.png)
