### PR TITLE
- feat(hud): change score font to Parchment

### DIFF
--- a/game/src/hud.js
+++ b/game/src/hud.js
@@ -6,7 +6,7 @@ var createHud = function () {
 
 	// Create a Text Block that can display the current score
 	scoreText = new BABYLON.GUI.TextBlock();
-	scoreText.fontFamily = "Comic Sans, Comic Sans MS";
+	scoreText.fontFamily = "Parchment";
 	scoreText.color = "white";
 	scoreText.fontSize = 48;
 	scoreText.verticalAlignment = BABYLON.GUI.TextBlock.VERTICAL_ALIGNMENT_TOP;


### PR DESCRIPTION
- The scoreboard is currently being drawn with the Comic Sans font, which is configured in hud.js. This commit changes the font to Parchment to enhance the visual appeal.